### PR TITLE
Gitignore binaries

### DIFF
--- a/prog/engine/.gitignore
+++ b/prog/engine/.gitignore
@@ -26,3 +26,7 @@
 
 # Temporary files
 *~
+
+# Codeblocks binary folders
+bin/
+obj/


### PR DESCRIPTION
Will make sure binaries are ignored by git.

This will make sure the size of the repository doesn't increase as more and more versions of binary files are added.

When you type git status, it will look as if the files aren't there.

Will also make it easier to see what actually changed between commits
